### PR TITLE
Fixing product name and version properly not displaying issue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,10 +223,10 @@
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)</slf4j.logging.package.import.version.range>
         <!--TODO: Check why we need to depend on SNAPSHOT -->
 
-        <carbon.transport.version>2.1.10-SNAPSHOT</carbon.transport.version>
+        <carbon.transport.version>2.1.9-SNAPSHOT</carbon.transport.version>
         <carbon.transport.package.import.version.range>[2.0.0, 2.2.0)</carbon.transport.package.import.version.range>
 
-        <carbon.messaging.version>1.0.10-SNAPSHOT</carbon.messaging.version>
+        <carbon.messaging.version>1.0.9-SNAPSHOT</carbon.messaging.version>
 
 
         <carbon.messaging.package.import.version.range>[0.0.0, 2.0.0)</carbon.messaging.package.import.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -223,10 +223,10 @@
         <slf4j.logging.package.import.version.range>[1.7.1, 2.0.0)</slf4j.logging.package.import.version.range>
         <!--TODO: Check why we need to depend on SNAPSHOT -->
 
-        <carbon.transport.version>2.1.9-SNAPSHOT</carbon.transport.version>
+        <carbon.transport.version>2.1.10-SNAPSHOT</carbon.transport.version>
         <carbon.transport.package.import.version.range>[2.0.0, 2.2.0)</carbon.transport.package.import.version.range>
 
-        <carbon.messaging.version>1.0.9-SNAPSHOT</carbon.messaging.version>
+        <carbon.messaging.version>1.0.10-SNAPSHOT</carbon.messaging.version>
 
 
         <carbon.messaging.package.import.version.range>[0.0.0, 2.0.0)</carbon.messaging.package.import.version.range>

--- a/product/src/assembly/bin.xml
+++ b/product/src/assembly/bin.xml
@@ -90,6 +90,17 @@
     </fileSets>
 
     <files>
-
+        <file>
+            <source>target/wso2carbon-kernel-${carbon.kernel.product.version}/bin/kernel-version.txt</source>
+            <outputDirectory>bin/</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>444</fileMode>
+        </file>
+        <file>
+            <source>target/wso2carbon-kernel-${carbon.kernel.product.version}/bin/README.txt</source>
+            <outputDirectory>bin/</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>444</fileMode>
+        </file>
     </files>
 </assembly>

--- a/product/src/assembly/filter.properties
+++ b/product/src/assembly/filter.properties
@@ -1,0 +1,4 @@
+product.name=WSO2 Integration
+product.version=1.0.0
+server.name=WSO2 Carbon Kernel
+server.version=5.1.0


### PR DESCRIPTION
In the README.txt file product name and version not displaying properly. This was due to not adding property information to the filter.properties file. Kernel information also not properly display in kernel-version.txt file and temporary this was fixed by adding an entry to the bin.xml. Proper fix needs to come from the kernel.
