### PR TITLE
Updating API resource path in sample passthrough.ballerina

### DIFF
--- a/samples/basic-routing/passthrough.ballerina
+++ b/samples/basic-routing/passthrough.ballerina
@@ -1,4 +1,4 @@
-@Path("/stocks")
+@Path("/stockquote")
 @Source(interface="default")
 @Service(tags = {
     "stock_info",
@@ -11,7 +11,7 @@ constant endpoint stockEP = new EndPoint("http://localhost:8080/stockquote/all")
 @GET
 @PUT
 @POST
-@Path("/getStocks")
+@Path("/stocks")
 resource passthrough(message m) {
     message response;
     response = invoke(endpointRef=stockEP, messageRef=m);


### PR DESCRIPTION
Currently the sample passthrough.ballerina file has defined the StockQuote API as follows:

```
GET /stocks/getStocks

{"stocks":[{"symbol":"GOOG","name":"Alphabet Inc.","last":652.3,"low":657.81,"high":643.15},{"symbol":"IBM","name":"International Business Machines","last":149.62,"low":150.78,"high":149.18},{"symbol":"AMZN","name":"Amazon.com","last":548.9,"low":553.2,"high":543.1}]}
```

IMO it would be better to follow RESTful standards when naming resource paths. This pull request has updated it as follows:

```
GET /stockquote/stocks

{"stocks":[{"symbol":"GOOG","name":"Alphabet Inc.","last":652.3,"low":657.81,"high":643.15},{"symbol":"IBM","name":"International Business Machines","last":149.62,"low":150.78,"high":149.18},{"symbol":"AMZN","name":"Amazon.com","last":548.9,"low":553.2,"high":543.1}]}
```